### PR TITLE
Add http:// to URL to fix 404 in sharer links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: This Workplace Learning website is supported by SkillsFuture Singapore
 title-abbreviated: us for any feedback on the website
 description: >- # this means to ignore newlines until "baseurl:"
   Description
-url: "workplacelearning.gov.sg" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://www.workplacelearning.gov.sg" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
Sharing the link via the share icons in the site causes the preview to show a "404 Page not Found" error. This is probably due to the misconfigured URL in _config.yml, which then carries over when it is used as a canonical URL in the `head` of the site. For example, when the page https://www.workplacelearning.gov.sg/framework/national-workplace-learning-framework/ is shared, facebook eventually resolves it to https://www.workplacelearning.gov.sg/framework/national-workplace-learning-framework/workplacelearning.gov.sg/framework/National-Workplace-Learning-Framework/